### PR TITLE
support for log4javascript, version 1.4.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>log4javascript</artifactId>
-    <version>1.4.10-SNAPSHOT</version>
+    <version>1.4.10</version>
     <name>log4javascript</name>
     <description>WebJar for log4javascript</description>
     <url>http://webjars.org</url>
@@ -41,7 +41,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>1.4.9</upstream.version>
+        <upstream.version>1.4.10</upstream.version>
         <upstream.url>http://downloads.sourceforge.net/project/log4javascript/log4javascript/${upstream.version}</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
     </properties>


### PR DESCRIPTION
update pom.xml of webjars/log4javascript project, to make version 1.4.10 of log4javascript accessible as webjar
